### PR TITLE
Fixed setup.py adn MANIFEST.in to include data.pkl in installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include cec2017/data.pkl

--- a/cec2017/MANIFEST.in
+++ b/cec2017/MANIFEST.in
@@ -1,1 +1,0 @@
-include data.pkl

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,12 @@
-from distutils.core import setup
+from setuptools import setup
+
+
 setup(name='CEC2017',
       version='1.0',
       description='CEC 2017 single objective optimization suite',
       author='Duncan Tilley',
       url='https://github.com/tilleyd/cec2017-py',
-      packages=['cec2017']
+      packages=['cec2017'],
+      include_package_data=True,
 )
+


### PR DESCRIPTION
While trying to use this package I noticed that it wasn't installing properly. The cec2017/data.pkl file was ommited in installation due to mislocation of MANIFEST.in and using distutils.core.setup instead setuptools.setup. I fixed it in this PR